### PR TITLE
#2.2 Redirect, Rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+.env

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,7 @@
 /** @type {import('next').NextConfig} */
+
+const API_KEY = process.env.API_KEY;
+
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
@@ -7,10 +10,18 @@ const nextConfig = {
       {
         source : "/old-blog/:path*",
         destination : "/new-blog/:path*",
-        permanent : false
-      }
+        permanent : false,
+      },
     ]
-  }
+  },
+  async rewrites() {
+    return [
+      {
+        source: "/api/movies",
+        destination: `https://api.themoviedb.org/3/movie/popular?api_key=${API_KEY}`,
+      },
+    ];
+  },
 }
 
 module.exports = nextConfig

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,15 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  async redirects() {
+    return [
+      {
+        source : "/old-blog/:path*",
+        destination : "/new-blog/:path*",
+        permanent : false
+      }
+    ]
+  }
 }
 
 module.exports = nextConfig

--- a/pages/index.js
+++ b/pages/index.js
@@ -14,14 +14,36 @@ export default function Home() {
     },[]);
 
     return (
-        <div>
+        <div className="container">
             <MyHead title="Home"/>
             {!movies && <h3>Loading...</h3>}
-            {movies?.map((movies) => (
-                <div key = {movies.id}>
-                    <h1>{movies.title}</h1>
+            {movies?.map((movie) => (
+                <div className="movie" key={movie.id}>
+                     <img src={`https://image.tmdb.org/t/p/w500/${movie.poster_path}`} />
+                    <h4>{movie.title}</h4>
                 </div>
             ))}
+             <style jsx>{`
+                .container {
+                display: grid;
+                grid-template-columns: 1fr 1fr;
+                padding: 20px;
+                gap: 20px;
+                }
+                .movie img {
+                max-width: 100%;
+                border-radius: 12px;
+                transition: transform 0.2s ease-in-out;
+                box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 12px;
+                }
+                .movie:hover img {
+                transform: scale(1.05) translateY(-10px);
+                }
+                .movie h4 {
+                font-size: 18px;
+                text-align: center;
+                }
+            `}</style>
         </div>
     ) 
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,13 +1,11 @@
 import { useEffect, useState } from "react"
 import MyHead from "../components/Head"
 
-const API_KEY = '10923b261ba94d897ac6b81148314a3f';
-
 export default function Home() {
     const [movies, setMovies] = useState();
     useEffect(()=> {
         (async () => {
-            const response = await fetch(`https://api.themoviedb.org/3/movie/popular?api_key=${API_KEY}`);
+            const response = await fetch(`/api/movies`);
             const { results }  = await response.json();
             setMovies(results);
         })();
@@ -19,7 +17,7 @@ export default function Home() {
             {!movies && <h3>Loading...</h3>}
             {movies?.map((movie) => (
                 <div className="movie" key={movie.id}>
-                     <img src={`https://image.tmdb.org/t/p/w500/${movie.poster_path}`} />
+                    <img src={`https://image.tmdb.org/t/p/w500/${movie.poster_path}`} />
                     <h4>{movie.title}</h4>
                 </div>
             ))}


### PR DESCRIPTION
```diff
- [Summary]
+ Redirect : 다른 URL로 redirect (URL 변경)
+ Rewrite : Request URL을 Masking
 ```

#2.2 Redirect and Rewrite
----------------
API keys를 숨길 수 있다 (NextJS에서 제공) : API key는 개발자도구나 소스코드에서 보이지 않도록 숨겨야 한다

- API key 숨기기
비공개 이유 : API key를 돈 내고 사는 경우 / API key 사용량에 제한이 있는 경우 (ex. 1분에 100번) / 다른 사람들의 남용
API key 위치 : Network에서 요청한 URL을 찾으면 Request URL에서 보여진다
방법 : redirect 또는 rewrite 사용

- next configuration file 설정
위치 : next.config.js

**`1. redirect**
- API key를 숨기지 않는 redirect
`1. source 설정
`2. redirect할 destination 설정 : 웹사이트 내부 and 외부 둘 다 설정 가능하다 (ex. 내부 : '/xxx', 외부 : 'https://xxx')
`3. permenent 여부 지정 : 브라우저나 검색엔진이 해당 정보를 기억할지 / 

- 주소가 변경된 경우의 destination 설정
source :  `/old-blog/:path`
destination : `/new-blog/:path`
path를 모두 catch하고 싶은 경우 : *표시 추가 (ex. "/old-blog/:path*" )
(catch 한다 = path의 뒷부분도 모두 가져온다)

**`2. rewrite**
- redirect와 다른 점
redirect는 URL이 변경되는걸 유저가 확인 가능하지만
rewrite는 URL이 변하지 않으면서 redirect 된다
= 내가 진짜로 요청한 URL은 숨겨진다 (가짜 fetching URL이 보여진다)
= **request는 masking 되어(가려져) 보이지 않는다**
= Network에서도 보여지지 않는다


(npm run dev하면 서버가 기동되고 있다)